### PR TITLE
Update animation `loops` parsing to more closely match Aseprite editor behavior

### DIFF
--- a/flixel/graphics/atlas/AseAtlas.hx
+++ b/flixel/graphics/atlas/AseAtlas.hx
@@ -118,7 +118,7 @@ abstract AseAtlasTagRepeat(Null<String>) from Null<String> to Null<String>
 	
 	inline function get_loops()
 	{
-		return this == null && toInt() > 1;
+		return this == null || toInt() > 1;
 	}
 	
 	@:to

--- a/flixel/graphics/atlas/AseAtlas.hx
+++ b/flixel/graphics/atlas/AseAtlas.hx
@@ -118,7 +118,7 @@ abstract AseAtlasTagRepeat(Null<String>) from Null<String> to Null<String>
 	
 	inline function get_loops()
 	{
-		return this != null && toInt() > 0;
+		return this == null && toInt() > 1;
 	}
 	
 	@:to


### PR DESCRIPTION
See #2947